### PR TITLE
Fixed .toml file 1.16 All

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,8 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[31,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[36,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+license="The MIT License (MIT)"
 # A URL to refer people to when problems occur with this mod
 issueTrackerURL="https://github.com/racerxdl/minecrowdcontrol/issues" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
@@ -47,6 +48,6 @@ This mod integrates with CrowdControl so you can stream at twitch and give crowd
 [[dependencies.minecrowdcontrol]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.16.1]"
+    versionRange="[1.16.1,]"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
This is a hotfix for to run the mod in all versions of 1.16 Minecraft Java through Forge